### PR TITLE
Fixed drop event properties

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "polymer-dragula",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Polymer implementation of dragula drag and drop handling",
   "main": "polymer-dragula.html",
   "license": "Apache-2.0",

--- a/polymer-dragula.html
+++ b/polymer-dragula.html
@@ -204,8 +204,8 @@ Polymer wrapper of dragula drag and drop library
               drake.on('dragend', function (el) {
                   this.fire('dragula-dragend', {el: el});
               }.bind(this));
-              drake.on('drop', function (el, target, source) {
-                  this.fire('dragula-drop', {el: el, target: target, source: source});
+              drake.on('drop', function (el, target, source, sibling) {
+                  this.fire('dragula-drop', {el: el, target: target, source: source, sibling: sibling});
               }.bind(this));
               drake.on('cancel', function (el, container, source) {
                   this.fire('dragula-cancel', {el: el, container: container, source: source});


### PR DESCRIPTION
Dragula exposes additional `sibling` object in `drop` event, which is useful when handling the event in the client code. I have added the missing sibling property to event proxy block.